### PR TITLE
Update dita2fo_change_tracking.xsl

### DIFF
--- a/com.antennahouse.pdf.review.oxygen/xsl/dita2fo_change_tracking.xsl
+++ b/com.antennahouse.pdf.review.oxygen/xsl/dita2fo_change_tracking.xsl
@@ -470,10 +470,13 @@
             </ph>
         </xsl:if>
     </xsl:template>
-
+    
+    <!-- Remove parent condition: [./parent::* => ahf:isMixedContentElement()]
+         to generate fo:change-bar-end normally. 
+         2023-11-30 t.makita 
+     -->
     <xsl:template match="processing-instruction()[ancestor-or-self::*[@class => contains-token('topic/topic')] => exists()]
                                                  [. => ahf:isInsertEndPi()]
-                                                 [./parent::* => ahf:isMixedContentElement()]
                                                  [ancestor-or-self::*[@class => contains-token('topic/prolog')] => empty()]"
                   mode="MODE_FIRST">
         <xsl:param name="prmTopic"          as="element()"              tunnel="yes" required="yes"/>


### PR DESCRIPTION
Fix fo:change-bar generation error. Sometimes change bar extends to the end of document without closing.